### PR TITLE
feat: implement Kalshi search

### DIFF
--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -45,7 +45,7 @@ impl Market for Kalshi {
         for contract in resp.current_page {
             for market in contract.markets {
                 let probability = market.last_price as f64 / 100.0;
-                let volume_24h = market.volume as f64;
+                let volume = market.volume as f64;
                 let title = if market.yes_subtitle.is_empty() {
                     contract.event_title.clone()
                 } else {
@@ -54,7 +54,7 @@ impl Market for Kalshi {
                 items.push(MarketItem {
                     title,
                     probability,
-                    volume_24h,
+                    volume,
                 });
             }
         }

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -1,7 +1,12 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use serde::Deserialize;
 
 use crate::market::{Market, MarketItem};
+
+const EVENTS_URL: &str = "https://api.elections.kalshi.com/trade-api/v2/events";
+const PAGE_LIMIT: u32 = 200;
+const MAX_PAGES: u32 = 5;
 
 pub struct Kalshi {
     client: reqwest::Client,
@@ -21,8 +26,77 @@ impl Market for Kalshi {
         "Kalshi"
     }
 
-    async fn search(&self, _query: &str) -> Result<Vec<MarketItem>> {
-        // PR3で実装
-        Ok(vec![])
+    async fn search(&self, query: &str) -> Result<Vec<MarketItem>> {
+        let query_lower = query.to_lowercase();
+        let mut items = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        for _ in 0..MAX_PAGES {
+            let mut req = self
+                .client
+                .get(EVENTS_URL)
+                .query(&[
+                    ("status", "open"),
+                    ("with_nested_markets", "true"),
+                    ("limit", &PAGE_LIMIT.to_string()),
+                ]);
+
+            if let Some(ref c) = cursor {
+                req = req.query(&[("cursor", c.as_str())]);
+            }
+
+            let resp: EventsResponse = req.send().await?.json().await?;
+
+            for event in &resp.events {
+                let title_match = event.title.to_lowercase().contains(&query_lower);
+                for market in &event.markets {
+                    if title_match || market.title.to_lowercase().contains(&query_lower) {
+                        let probability = market
+                            .last_price_dollars
+                            .parse::<f64>()
+                            .unwrap_or(0.0);
+                        let volume_24h = market
+                            .volume_24h_fp
+                            .parse::<f64>()
+                            .unwrap_or(0.0);
+                        items.push(MarketItem {
+                            title: market.title.clone(),
+                            probability,
+                            volume_24h,
+                        });
+                    }
+                }
+            }
+
+            if resp.cursor.is_empty() {
+                break;
+            }
+            cursor = Some(resp.cursor);
+        }
+
+        Ok(items)
     }
+}
+
+#[derive(Deserialize)]
+struct EventsResponse {
+    #[serde(default)]
+    cursor: String,
+    events: Vec<KalshiEvent>,
+}
+
+#[derive(Deserialize)]
+struct KalshiEvent {
+    title: String,
+    #[serde(default)]
+    markets: Vec<KalshiMarket>,
+}
+
+#[derive(Deserialize)]
+struct KalshiMarket {
+    title: String,
+    #[serde(default)]
+    last_price_dollars: String,
+    #[serde(default)]
+    volume_24h_fp: String,
 }

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -4,9 +4,9 @@ use serde::Deserialize;
 
 use crate::market::{Market, MarketItem};
 
-const EVENTS_URL: &str = "https://api.elections.kalshi.com/trade-api/v2/events";
-const PAGE_LIMIT: u32 = 200;
-const MAX_PAGES: u32 = 5;
+const SEARCH_URL: &str =
+    "https://api.elections.kalshi.com/v1/search/series";
+const PAGE_SIZE: u32 = 24;
 
 pub struct Kalshi {
     client: reqwest::Client,
@@ -27,76 +27,59 @@ impl Market for Kalshi {
     }
 
     async fn search(&self, query: &str) -> Result<Vec<MarketItem>> {
-        let query_lower = query.to_lowercase();
+        let resp: SearchResponse = self
+            .client
+            .get(SEARCH_URL)
+            .query(&[
+                ("query", query),
+                ("order_by", "querymatch"),
+                ("reverse", "false"),
+                ("page_size", &PAGE_SIZE.to_string()),
+            ])
+            .send()
+            .await?
+            .json()
+            .await?;
+
         let mut items = Vec::new();
-        let mut cursor: Option<String> = None;
-
-        for _ in 0..MAX_PAGES {
-            let mut req = self
-                .client
-                .get(EVENTS_URL)
-                .query(&[
-                    ("status", "open"),
-                    ("with_nested_markets", "true"),
-                    ("limit", &PAGE_LIMIT.to_string()),
-                ]);
-
-            if let Some(ref c) = cursor {
-                req = req.query(&[("cursor", c.as_str())]);
+        for contract in resp.current_page {
+            for market in contract.markets {
+                let probability = market.last_price as f64 / 100.0;
+                let volume_24h = market.volume as f64;
+                let title = if market.yes_subtitle.is_empty() {
+                    contract.event_title.clone()
+                } else {
+                    format!("{} — {}", contract.event_title, market.yes_subtitle)
+                };
+                items.push(MarketItem {
+                    title,
+                    probability,
+                    volume_24h,
+                });
             }
-
-            let resp: EventsResponse = req.send().await?.json().await?;
-
-            for event in &resp.events {
-                let title_match = event.title.to_lowercase().contains(&query_lower);
-                for market in &event.markets {
-                    if title_match || market.title.to_lowercase().contains(&query_lower) {
-                        let probability = market
-                            .last_price_dollars
-                            .parse::<f64>()
-                            .unwrap_or(0.0);
-                        let volume_24h = market
-                            .volume_24h_fp
-                            .parse::<f64>()
-                            .unwrap_or(0.0);
-                        items.push(MarketItem {
-                            title: market.title.clone(),
-                            probability,
-                            volume_24h,
-                        });
-                    }
-                }
-            }
-
-            if resp.cursor.is_empty() {
-                break;
-            }
-            cursor = Some(resp.cursor);
         }
-
         Ok(items)
     }
 }
 
 #[derive(Deserialize)]
-struct EventsResponse {
-    #[serde(default)]
-    cursor: String,
-    events: Vec<KalshiEvent>,
+struct SearchResponse {
+    current_page: Vec<Contract>,
 }
 
 #[derive(Deserialize)]
-struct KalshiEvent {
-    title: String,
+struct Contract {
+    event_title: String,
     #[serde(default)]
     markets: Vec<KalshiMarket>,
 }
 
 #[derive(Deserialize)]
 struct KalshiMarket {
-    title: String,
     #[serde(default)]
-    last_price_dollars: String,
+    last_price: u32,
     #[serde(default)]
-    volume_24h_fp: String,
+    volume: u64,
+    #[serde(default)]
+    yes_subtitle: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ enum Commands {
         /// Search query (e.g. "trump", "bitcoin")
         query: String,
 
-        /// Max results per platform (default: 20)
+        /// Max results per platform (1-100, default: 20)
         #[arg(short, long, default_value_t = 20)]
         limit: usize,
     },
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Search { query, limit } => {
+            let limit = limit.clamp(1, 100);
             let markets: Vec<Box<dyn Market>> = vec![
                 Box::new(Polymarket::new()),
                 Box::new(Kalshi::new()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,8 @@ async fn main() -> anyhow::Result<()> {
 
             for m in &markets {
                 let results = m.search(&query).await?;
-                println!("\n{} ({} results)", m.name(), results.len());
+                let shown = results.len().min(limit);
+                println!("\n{} ({}/{} results)", m.name(), shown, results.len());
                 println!("{:<50}  {:>6}  {:>10}", "Title", "Prob", "Volume");
                 println!("{}", "─".repeat(72));
                 for item in results.iter().take(limit) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,14 +66,14 @@ async fn main() -> anyhow::Result<()> {
             for m in &markets {
                 let results = m.search(&query).await?;
                 println!("\n{} ({} results)", m.name(), results.len());
-                println!("{:<50}  {:>6}  {:>10}", "Title", "Prob", "Vol/24h");
+                println!("{:<50}  {:>6}  {:>10}", "Title", "Prob", "Volume");
                 println!("{}", "─".repeat(72));
                 for item in &results {
                     println!(
                         "{:<50}  {:>5.1}%  {:>9.1}k",
                         truncate(&item.title, 50),
                         item.probability * 100.0,
-                        item.volume_24h / 1000.0,
+                        item.volume / 1000.0,
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,14 +21,19 @@ enum Commands {
     Search {
         /// Search query (e.g. "trump", "bitcoin")
         query: String,
+
+        /// Max results per platform (default: 20)
+        #[arg(short, long, default_value_t = 20)]
+        limit: usize,
     },
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max - 3])
+        let truncated: String = s.chars().take(max - 3).collect();
+        format!("{truncated}...")
     }
 }
 
@@ -50,6 +55,11 @@ mod tests {
     fn truncate_long_string() {
         assert_eq!(truncate("hello world", 8), "hello...");
     }
+
+    #[test]
+    fn truncate_multibyte() {
+        assert_eq!(truncate("51st state — Puerto Rico", 20), "51st state — Puer...");
+    }
 }
 
 #[tokio::main]
@@ -57,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Search { query } => {
+        Commands::Search { query, limit } => {
             let markets: Vec<Box<dyn Market>> = vec![
                 Box::new(Polymarket::new()),
                 Box::new(Kalshi::new()),
@@ -68,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
                 println!("\n{} ({} results)", m.name(), results.len());
                 println!("{:<50}  {:>6}  {:>10}", "Title", "Prob", "Volume");
                 println!("{}", "─".repeat(72));
-                for item in &results {
+                for item in results.iter().take(limit) {
                     println!(
                         "{:<50}  {:>5.1}%  {:>9.1}k",
                         truncate(&item.title, 50),

--- a/src/market.rs
+++ b/src/market.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 pub struct MarketItem {
     pub title: String,
     pub probability: f64,
-    pub volume_24h: f64,
+    pub volume: f64,
 }
 
 /// Polymarket/Kalshi両方が実装する統一インターフェース

--- a/src/polymarket.rs
+++ b/src/polymarket.rs
@@ -37,17 +37,12 @@ impl Market for Polymarket {
 
         let mut items = Vec::new();
         for event in resp.events {
-            let vol_per_market = if event.markets.is_empty() {
-                0.0
-            } else {
-                event.volume24hr / event.markets.len() as f64
-            };
             for market in event.markets {
                 let probability = parse_yes_price(&market.outcome_prices);
                 items.push(MarketItem {
                     title: market.question,
                     probability,
-                    volume_24h: vol_per_market,
+                    volume: market.volume.parse::<f64>().unwrap_or(0.0),
                 });
             }
         }
@@ -70,8 +65,6 @@ struct SearchResponse {
 
 #[derive(Deserialize)]
 struct Event {
-    #[serde(default)]
-    volume24hr: f64,
     markets: Vec<PolymarketMarket>,
 }
 
@@ -80,6 +73,8 @@ struct PolymarketMarket {
     question: String,
     #[serde(rename = "outcomePrices")]
     outcome_prices: String,
+    #[serde(default)]
+    volume: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Kalshi 検索API (`/v1/search/series`) を使ったキーワード検索を実装
- `last_price`（0-100）を確率として、`volume`（累計取引量）を表示
- `yes_subtitle` がある場合はイベントタイトルと結合して表示
- Polymarket側も `volume_24h` → `volume`（累計取引量）に統一

## 動作確認
```
$ cargo run -- search "trump"

Polymarket (53 results)
Title                                                 Prob      Volume
────────────────────────────────────────────────────────────────────────
Trump announces end of military operations agai...   81.5%      250.3k
...

Kalshi (416 results)
Title                                                 Prob      Volume
────────────────────────────────────────────────────────────────────────
2028 Republican presidential nominee — J.D. V...     36.0%     4594.7k
2028 Republican presidential nominee — Marco ...     27.0%     6599.3k
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)