### PR TITLE
feat: side-by-side display with parallel fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# predx
+
+Polymarket と Kalshi を横断検索して確率を並べて表示する CLI ツール。
+
+## インストール
+
+```bash
+cargo install --path .
+```
+
+## 使い方
+
+```bash
+# 基本の検索
+predx search "trump"
+
+# 表示件数を指定（デフォルト: 20、最大: 100）
+predx search "bitcoin" -l 5
+```
+
+### 出力例
+
+```
+Polymarket (5/44)                       │  Kalshi (5/774)
+──────────────────────────────────────  │  ──────────────────────────────────────
+Will the price of B... 100.0%    159.1k  │  When will Bitcoin h...  12.0%    121.3k
+Will the price of B... 100.0%    102.6k  │  When will Bitcoin h...   5.0%     83.0k
+Will the price of B... 100.0%    187.3k  │  When will Bitcoin h...   5.0%    183.6k
+Will the price of B... 100.0%    247.9k  │  When will Bitcoin h...   2.0%     27.4k
+Will the price of B... 100.0%    405.1k  │  When will Bitcoin h...   1.0%  11014.0k
+```
+
+## 開発
+
+```bash
+# ビルド
+cargo build
+
+# テスト
+cargo test
+
+# 開発中の実行
+cargo run -- search "trump"
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod polymarket;
 use clap::{Parser, Subcommand};
 
 use crate::kalshi::Kalshi;
-use crate::market::Market;
+use crate::market::{Market, MarketItem};
 use crate::polymarket::Polymarket;
 
 #[derive(Parser)]
@@ -28,12 +28,58 @@ enum Commands {
     },
 }
 
+const COL_WIDTH: usize = 38;
+const GAP: &str = "  │  ";
+
 fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         s.to_string()
     } else {
         let truncated: String = s.chars().take(max - 3).collect();
         format!("{truncated}...")
+    }
+}
+
+fn format_item(item: &MarketItem) -> String {
+    format!(
+        "{:<title_w$} {:>5.1}%  {:>7.1}k",
+        truncate(&item.title, COL_WIDTH - 16),
+        item.probability * 100.0,
+        item.volume / 1000.0,
+        title_w = COL_WIDTH - 16,
+    )
+}
+
+fn format_empty() -> String {
+    " ".repeat(COL_WIDTH)
+}
+
+fn print_side_by_side(
+    left_name: &str,
+    left_items: &[MarketItem],
+    right_name: &str,
+    right_items: &[MarketItem],
+    limit: usize,
+) {
+    let left_shown = left_items.len().min(limit);
+    let right_shown = right_items.len().min(limit);
+
+    let left_header = format!(
+        "{} ({}/{})",
+        left_name, left_shown, left_items.len()
+    );
+    let right_header = format!(
+        "{} ({}/{})",
+        right_name, right_shown, right_items.len()
+    );
+    println!("\n{:<w$}{}{}", left_header, GAP, right_header, w = COL_WIDTH);
+    println!("{}{}{}", "─".repeat(COL_WIDTH), GAP, "─".repeat(COL_WIDTH));
+
+    let rows = left_shown.max(right_shown);
+    for i in 0..rows {
+        let left = left_items.get(i).map(format_item).unwrap_or_else(format_empty);
+        let right = right_items.get(i).map(format_item).unwrap_or_else(format_empty);
+        println!("{:<w$}{}{}", left, GAP, right, w = COL_WIDTH);
     }
 }
 
@@ -69,26 +115,20 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::Search { query, limit } => {
             let limit = limit.clamp(1, 100);
-            let markets: Vec<Box<dyn Market>> = vec![
-                Box::new(Polymarket::new()),
-                Box::new(Kalshi::new()),
-            ];
 
-            for m in &markets {
-                let results = m.search(&query).await?;
-                let shown = results.len().min(limit);
-                println!("\n{} ({}/{} results)", m.name(), shown, results.len());
-                println!("{:<50}  {:>6}  {:>10}", "Title", "Prob", "Volume");
-                println!("{}", "─".repeat(72));
-                for item in results.iter().take(limit) {
-                    println!(
-                        "{:<50}  {:>5.1}%  {:>9.1}k",
-                        truncate(&item.title, 50),
-                        item.probability * 100.0,
-                        item.volume / 1000.0,
-                    );
-                }
-            }
+            let poly = Polymarket::new();
+            let kal = Kalshi::new();
+
+            let (poly_res, kal_res) =
+                tokio::try_join!(poly.search(&query), kal.search(&query))?;
+
+            print_side_by_side(
+                poly.name(),
+                &poly_res,
+                kal.name(),
+                &kal_res,
+                limit,
+            );
 
             Ok(())
         }


### PR DESCRIPTION
## Summary
- Polymarket / Kalshi の検索結果を横並びで表示
- `tokio::try_join!` で両プラットフォームを並列取得（逐次より高速）
- 件数が異なる場合は短い方を空白で埋めて整列
- README追加（インストール方法・使い方・開発手順）
- `cargo install --path .` で `predx` コマンドとしてグローバルに使えるように

## 動作確認
```
$ predx search "iran" -l 5

Polymarket (5/39)                       │  Kalshi (5/173)
──────────────────────────────────────  │  ──────────────────────────────────────
US x Iran permanent...  18.5%  10198.1k  │  US-Iran nuclear dea...  46.0%   1063.3k
US x Iran permanent...  35.5%   3931.9k  │  US-Iran nuclear dea...  56.0%    100.2k
US x Iran permanent...  57.5%   2093.2k  │  US-Iran nuclear dea...  61.0%   1120.8k
US x Iran permanent...  66.5%    751.8k  │  US-Iran nuclear dea...  64.0%     55.1k
Iran x Israel/US co...   0.0%      0.0k  │  US-Iran nuclear dea...  75.0%   1156.9k
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)