### PR TITLE
feat: JSON/CSV 出力フォーマット対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ predx search "trump" --sort prob
 
 # 解決済み市場も含める
 predx search "trump" --inactive
+
+# JSON/CSV で出力（他ツール連携・パイプ処理向け）
+predx search "trump" --format json
+predx search "trump" --format csv | column -t -s,
 ```
 
 ### 出力例

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -52,6 +52,8 @@ impl Market for Kalshi {
                     format!("{} — {}", contract.event_title, market.yes_subtitle)
                 };
                 items.push(MarketItem {
+                    id: market.ticker,
+                    platform: "kalshi",
                     title,
                     probability,
                     volume,
@@ -77,6 +79,8 @@ struct Contract {
 
 #[derive(Deserialize)]
 struct KalshiMarket {
+    #[serde(default)]
+    ticker: String,
     #[serde(default)]
     last_price: u32,
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,16 @@ enum SortKey {
     Prob,
 }
 
+#[derive(Clone, ValueEnum)]
+enum OutputFormat {
+    /// Human-readable side-by-side table (default)
+    Table,
+    /// JSON array suitable for piping into jq
+    Json,
+    /// CSV with header row
+    Csv,
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Search markets by keyword
@@ -41,6 +51,10 @@ enum Commands {
         /// Include resolved/closed markets
         #[arg(long)]
         inactive: bool,
+
+        /// Output format: table, json, csv
+        #[arg(short, long, default_value = "table")]
+        format: OutputFormat,
     },
 }
 
@@ -101,12 +115,42 @@ fn print_side_by_side(
 }
 
 
+fn print_json(items: &[&MarketItem]) -> anyhow::Result<()> {
+    let out = serde_json::to_string_pretty(items)?;
+    println!("{}", out);
+    Ok(())
+}
+
+fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        let escaped = s.replace('"', "\"\"");
+        format!("\"{}\"", escaped)
+    } else {
+        s.to_string()
+    }
+}
+
+fn print_csv(items: &[&MarketItem]) {
+    println!("platform,id,title,probability,volume,active");
+    for item in items {
+        println!(
+            "{},{},{},{},{},{}",
+            item.platform,
+            csv_escape(&item.id),
+            csv_escape(&item.title),
+            item.probability,
+            item.volume,
+            item.active,
+        );
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Search { query, limit, sort, inactive } => {
+        Commands::Search { query, limit, sort, inactive, format } => {
             let limit = limit.clamp(1, 100);
 
             let poly = Polymarket::new();
@@ -127,13 +171,33 @@ async fn main() -> anyhow::Result<()> {
             poly_res.sort_by(comparator);
             kal_res.sort_by(comparator);
 
-            print_side_by_side(
-                poly.name(),
-                &poly_res,
-                kal.name(),
-                &kal_res,
-                limit,
-            );
+            match format {
+                OutputFormat::Table => {
+                    print_side_by_side(
+                        poly.name(),
+                        &poly_res,
+                        kal.name(),
+                        &kal_res,
+                        limit,
+                    );
+                }
+                OutputFormat::Json => {
+                    let items: Vec<&MarketItem> = poly_res
+                        .iter()
+                        .take(limit)
+                        .chain(kal_res.iter().take(limit))
+                        .collect();
+                    print_json(&items)?;
+                }
+                OutputFormat::Csv => {
+                    let items: Vec<&MarketItem> = poly_res
+                        .iter()
+                        .take(limit)
+                        .chain(kal_res.iter().take(limit))
+                        .collect();
+                    print_csv(&items);
+                }
+            }
 
             Ok(())
         }

--- a/src/market.rs
+++ b/src/market.rs
@@ -1,9 +1,12 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use serde::Serialize;
 
 /// 検索結果1件分のデータ
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct MarketItem {
+    pub id: String,
+    pub platform: &'static str,
     pub title: String,
     pub probability: f64,
     pub volume: f64,

--- a/src/polymarket.rs
+++ b/src/polymarket.rs
@@ -40,6 +40,8 @@ impl Market for Polymarket {
             for market in event.markets {
                 let probability = parse_yes_price(&market.outcome_prices);
                 items.push(MarketItem {
+                    id: market.id,
+                    platform: "polymarket",
                     title: market.question,
                     probability,
                     volume: market.volume.parse::<f64>().unwrap_or(0.0),
@@ -71,6 +73,8 @@ struct Event {
 
 #[derive(Deserialize)]
 struct PolymarketMarket {
+    #[serde(default)]
+    id: String,
     question: String,
     #[serde(rename = "outcomePrices")]
     outcome_prices: String,


### PR DESCRIPTION
## Summary
- `search` に `--format <table|json|csv>` を追加（既定は `table` で従来表示のまま）
- `MarketItem` に `id`（Polymarket: `id` / Kalshi: `ticker`）と `platform` を追加し `Serialize` 対応
- JSON は `serde_json` で pretty 出力、CSV はヘッダ付き・カンマ/改行/ダブルクオートをエスケープ

Closes #5

## Test plan
- [x] `cargo test` が通る（既存ユニットテスト継続）
- [x] `cargo run -- search "trump" -l 2` でテーブル表示が従来どおり
- [x] `cargo run -- search "trump" -l 2 --format json` が構造化データを出力
- [x] `cargo run -- search "trump" -l 2 --format csv` でヘッダ付きCSV出力

## 補足
- issue で「検討」扱いだった「非TTYで自動JSON」は未対応。別issueで是非を議論するほうがよさそう

🤖 Generated with [Claude Code](https://claude.com/claude-code)