### PR TITLE
feat: watch コマンド（MVP: 変動検知を標準出力へ）

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ predx search "trump" --inactive
 # JSON/CSV で出力（他ツール連携・パイプ処理向け）
 predx search "trump" --format json
 predx search "trump" --format csv | column -t -s,
+
+# 確率変動を定期的に監視（しきい値を超えたら通知）
+predx watch "trump 2028" --interval 60 --threshold 5 --limit 5
+# --duration 30 で30分後に自動終了。Ctrl+Cで即停止
 ```
 
 ### 出力例

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod kalshi;
 mod market;
 mod polymarket;
+mod watch;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -55,6 +56,28 @@ enum Commands {
         /// Output format: table, json, csv
         #[arg(short, long, default_value = "table")]
         format: OutputFormat,
+    },
+
+    /// Watch markets and report when probability changes exceed a threshold
+    Watch {
+        /// Search query (e.g. "trump 2028")
+        query: String,
+
+        /// Polling interval in seconds
+        #[arg(short, long, default_value_t = 60)]
+        interval: u64,
+
+        /// Change threshold in percentage points (e.g. 5 means 5pp)
+        #[arg(short, long, default_value_t = 5.0)]
+        threshold: f64,
+
+        /// Number of top markets per platform to watch
+        #[arg(short, long, default_value_t = 5)]
+        limit: usize,
+
+        /// Stop watching after N minutes
+        #[arg(short, long)]
+        duration: Option<u64>,
     },
 }
 
@@ -200,6 +223,18 @@ async fn main() -> anyhow::Result<()> {
             }
 
             Ok(())
+        }
+        Commands::Watch { query, interval, threshold, limit, duration } => {
+            let limit = limit.clamp(1, 100);
+            let interval = interval.max(1);
+            watch::run(watch::WatchOptions {
+                query,
+                interval,
+                threshold,
+                limit,
+                duration,
+            })
+            .await
         }
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::time::{Instant, sleep};
+
+use crate::kalshi::Kalshi;
+use crate::market::{Market, MarketItem};
+use crate::polymarket::Polymarket;
+
+pub struct WatchOptions {
+    pub query: String,
+    pub interval: u64,
+    pub threshold: f64,
+    pub limit: usize,
+    pub duration: Option<u64>,
+}
+
+pub async fn run(opts: WatchOptions) -> Result<()> {
+    let poly = Polymarket::new();
+    let kal = Kalshi::new();
+
+    let deadline = opts.duration.map(|m| Instant::now() + Duration::from_secs(m * 60));
+    let mut prev: HashMap<String, f64> = HashMap::new();
+    let mut tick = 0u64;
+
+    println!(
+        "# watching \"{}\" — interval={}s threshold={}% limit={}",
+        opts.query, opts.interval, opts.threshold, opts.limit,
+    );
+    if let Some(d) = opts.duration {
+        println!("# stop after {} minute(s)", d);
+    }
+    println!("# press Ctrl+C to stop");
+
+    loop {
+        let snapshot = fetch_snapshot(&poly, &kal, &opts.query, opts.limit).await;
+        match snapshot {
+            Ok(items) => {
+                let now = chrono_now();
+                for item in &items {
+                    let key = format!("{}:{}", item.platform, item.id);
+                    let curr = item.probability * 100.0;
+                    if let Some(&prev_p) = prev.get(&key) {
+                        let diff = curr - prev_p;
+                        if diff.abs() >= opts.threshold {
+                            let sign = if diff >= 0.0 { "+" } else { "" };
+                            println!(
+                                "[{}] [{}] {}  {:.1}% → {:.1}% ({}{:.1}pp)",
+                                now, item.platform, item.title, prev_p, curr, sign, diff,
+                            );
+                        }
+                    } else if tick == 0 {
+                        println!(
+                            "[{}] [{}] {}  baseline {:.1}%",
+                            now, item.platform, item.title, curr,
+                        );
+                    }
+                    prev.insert(key, curr);
+                }
+            }
+            Err(e) => {
+                eprintln!("[warn] fetch failed: {}", e);
+            }
+        }
+
+        tick += 1;
+
+        if let Some(dl) = deadline
+            && Instant::now() >= dl
+        {
+            println!("# duration reached, stopping");
+            return Ok(());
+        }
+
+        let wait = Duration::from_secs(opts.interval);
+        tokio::select! {
+            _ = sleep(wait) => {}
+            _ = tokio::signal::ctrl_c() => {
+                println!("\n# interrupted, stopping");
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn fetch_snapshot(
+    poly: &Polymarket,
+    kal: &Kalshi,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<MarketItem>> {
+    let (mut poly_res, mut kal_res) = tokio::try_join!(poly.search(query), kal.search(query))?;
+    poly_res.retain(|item| item.active);
+    kal_res.retain(|item| item.active);
+
+    let cmp = |a: &MarketItem, b: &MarketItem| {
+        b.volume
+            .partial_cmp(&a.volume)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    };
+    poly_res.sort_by(cmp);
+    kal_res.sort_by(cmp);
+
+    let mut items: Vec<MarketItem> = poly_res.into_iter().take(limit).collect();
+    items.extend(kal_res.into_iter().take(limit));
+    Ok(items)
+}
+
+fn chrono_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let h = (secs / 3600) % 24;
+    let m = (secs / 60) % 60;
+    let s = secs % 60;
+    format!("{:02}:{:02}:{:02}Z", h, m, s)
+}


### PR DESCRIPTION
## Summary
- `predx watch <query>` サブコマンドを追加。キーワードで上位N件を定期取得し、前回との確率差が `--threshold` (単位: パーセントポイント) を超えたら stdout に出力
- オプション: `--interval`（秒, 既定60）/ `--threshold`（pp, 既定5）/ `--limit`（既定5）/ `--duration`（分, 任意）
- Ctrl+C で即停止、`--duration` 指定時はそれを超えたら自動終了
- 1周目は baseline を全件表示し、2周目以降は threshold を超えた変動のみ出力

Refs #6（MVPスコープ。`--webhook` / `--log` / `--market-id` / 指数バックオフは別PRへ分割予定）

## Test plan
- [x] `cargo test` 既存テスト通過
- [x] `cargo run -- watch "trump" --interval 3 --threshold 0.1 --limit 3 --duration 1` で baseline 出力→1分後自動終了
- [x] Ctrl+C で即停止することを手動確認
- [ ] 長時間動かして実際のオッズ変動が検知される（実運用確認）

## 設計メモ
- 市場の識別は `"{platform}:{id}"` を HashMap キーに
- ソート・アクティブフィルタは `search` と同じ順序で固定（出来高降順・アクティブのみ）。将来 `--sort` や `--inactive` に対応するかは運用してから決める

🤖 Generated with [Claude Code](https://claude.com/claude-code)