### PR TITLE
feat(watch): Discord/Slack webhook 通知対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ predx search "trump" --format csv | column -t -s,
 # 確率変動を定期的に監視（しきい値を超えたら通知）
 predx watch "trump 2028" --interval 60 --threshold 5 --limit 5
 # --duration 30 で30分後に自動終了。Ctrl+Cで即停止
+
+# Discord / Slack webhook に変動アラートを飛ばす
+predx watch "bitcoin" --threshold 3 --webhook https://discord.com/api/webhooks/...
+predx watch "bitcoin" --threshold 3 --webhook https://hooks.slack.com/services/...
 ```
 
 ### 出力例

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,10 @@ enum Commands {
         /// Stop watching after N minutes
         #[arg(short, long)]
         duration: Option<u64>,
+
+        /// Discord/Slack webhook URL to post threshold alerts
+        #[arg(short, long)]
+        webhook: Option<String>,
     },
 }
 
@@ -224,7 +228,7 @@ async fn main() -> anyhow::Result<()> {
 
             Ok(())
         }
-        Commands::Watch { query, interval, threshold, limit, duration } => {
+        Commands::Watch { query, interval, threshold, limit, duration, webhook } => {
             let limit = limit.clamp(1, 100);
             let interval = interval.max(1);
             watch::run(watch::WatchOptions {
@@ -233,6 +237,7 @@ async fn main() -> anyhow::Result<()> {
                 threshold,
                 limit,
                 duration,
+                webhook,
             })
             .await
         }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Result;
+use serde_json::json;
 use tokio::time::{Instant, sleep};
 
 use crate::kalshi::Kalshi;
@@ -14,11 +15,38 @@ pub struct WatchOptions {
     pub threshold: f64,
     pub limit: usize,
     pub duration: Option<u64>,
+    pub webhook: Option<String>,
+}
+
+enum WebhookFlavor {
+    Discord,
+    Slack,
+}
+
+fn detect_flavor(url: &str) -> WebhookFlavor {
+    if url.contains("discord.com") || url.contains("discordapp.com") {
+        WebhookFlavor::Discord
+    } else {
+        WebhookFlavor::Slack
+    }
+}
+
+async fn post_webhook(client: &reqwest::Client, url: &str, message: &str) -> Result<()> {
+    let body = match detect_flavor(url) {
+        WebhookFlavor::Discord => json!({ "content": message }),
+        WebhookFlavor::Slack => json!({ "text": message }),
+    };
+    let resp = client.post(url).json(&body).send().await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("webhook returned status {}", resp.status());
+    }
+    Ok(())
 }
 
 pub async fn run(opts: WatchOptions) -> Result<()> {
     let poly = Polymarket::new();
     let kal = Kalshi::new();
+    let http = reqwest::Client::new();
 
     let deadline = opts.duration.map(|m| Instant::now() + Duration::from_secs(m * 60));
     let mut prev: HashMap<String, f64> = HashMap::new();
@@ -30,6 +58,9 @@ pub async fn run(opts: WatchOptions) -> Result<()> {
     );
     if let Some(d) = opts.duration {
         println!("# stop after {} minute(s)", d);
+    }
+    if opts.webhook.is_some() {
+        println!("# webhook notifications enabled");
     }
     println!("# press Ctrl+C to stop");
 
@@ -45,10 +76,16 @@ pub async fn run(opts: WatchOptions) -> Result<()> {
                         let diff = curr - prev_p;
                         if diff.abs() >= opts.threshold {
                             let sign = if diff >= 0.0 { "+" } else { "" };
-                            println!(
+                            let line = format!(
                                 "[{}] [{}] {}  {:.1}% → {:.1}% ({}{:.1}pp)",
                                 now, item.platform, item.title, prev_p, curr, sign, diff,
                             );
+                            println!("{}", line);
+                            if let Some(url) = &opts.webhook
+                                && let Err(e) = post_webhook(&http, url, &line).await
+                            {
+                                eprintln!("[warn] webhook failed: {}", e);
+                            }
                         }
                     } else if tick == 0 {
                         println!(


### PR DESCRIPTION
## Summary
- `predx watch` に `--webhook <url>` を追加
- URL ホスト名で Discord / Slack を自動判定し、Discord は \`{\"content\": ...}\`、Slack は \`{\"text\": ...}\` で POST
- webhook 失敗時はログして監視ループは継続（一時的な通信エラーで止めない）

Refs #6

## Test plan
- [x] \`cargo test\`
- [x] \`--webhook https://httpbin.org/post\` で1分回して、fetch失敗やwebhook失敗のwarningが出ないことを確認（200 OKが返ってる）
- [ ] 実際の Discord / Slack webhook で受信確認（ユーザー環境で）

## 備考
- `--log` と `--market-id` は後続PRで対応予定（#6 に残っている項目）

🤖 Generated with [Claude Code](https://claude.com/claude-code)