### PR TITLE
feat(watch): --log 追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ predx watch "trump 2028" --interval 60 --threshold 5 --limit 5
 # Discord / Slack webhook に変動アラートを飛ばす
 predx watch "bitcoin" --threshold 3 --webhook https://discord.com/api/webhooks/...
 predx watch "bitcoin" --threshold 3 --webhook https://hooks.slack.com/services/...
+
+# ファイルに追記記録（baseline とアラートをすべて残す）
+predx watch "trump 2028" --log predx.log
 ```
 
 ### 出力例

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,10 @@ enum Commands {
         /// Discord/Slack webhook URL to post threshold alerts
         #[arg(short, long)]
         webhook: Option<String>,
+
+        /// Append alerts and baselines to this file
+        #[arg(long)]
+        log: Option<std::path::PathBuf>,
     },
 }
 
@@ -228,7 +232,7 @@ async fn main() -> anyhow::Result<()> {
 
             Ok(())
         }
-        Commands::Watch { query, interval, threshold, limit, duration, webhook } => {
+        Commands::Watch { query, interval, threshold, limit, duration, webhook, log } => {
             let limit = limit.clamp(1, 100);
             let interval = interval.max(1);
             watch::run(watch::WatchOptions {
@@ -238,6 +242,7 @@ async fn main() -> anyhow::Result<()> {
                 limit,
                 duration,
                 webhook,
+                log,
             })
             .await
         }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::json;
 use tokio::time::{Instant, sleep};
 
@@ -16,6 +19,17 @@ pub struct WatchOptions {
     pub limit: usize,
     pub duration: Option<u64>,
     pub webhook: Option<String>,
+    pub log: Option<PathBuf>,
+}
+
+fn append_log(path: &PathBuf, line: &str) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open log file {}", path.display()))?;
+    writeln!(file, "{}", line).with_context(|| "failed to write log line")?;
+    Ok(())
 }
 
 enum WebhookFlavor {
@@ -62,6 +76,9 @@ pub async fn run(opts: WatchOptions) -> Result<()> {
     if opts.webhook.is_some() {
         println!("# webhook notifications enabled");
     }
+    if let Some(p) = &opts.log {
+        println!("# logging to {}", p.display());
+    }
     println!("# press Ctrl+C to stop");
 
     loop {
@@ -86,12 +103,23 @@ pub async fn run(opts: WatchOptions) -> Result<()> {
                             {
                                 eprintln!("[warn] webhook failed: {}", e);
                             }
+                            if let Some(path) = &opts.log
+                                && let Err(e) = append_log(path, &line)
+                            {
+                                eprintln!("[warn] log write failed: {}", e);
+                            }
                         }
                     } else if tick == 0 {
-                        println!(
+                        let baseline = format!(
                             "[{}] [{}] {}  baseline {:.1}%",
                             now, item.platform, item.title, curr,
                         );
+                        println!("{}", baseline);
+                        if let Some(path) = &opts.log
+                            && let Err(e) = append_log(path, &baseline)
+                        {
+                            eprintln!("[warn] log write failed: {}", e);
+                        }
                     }
                     prev.insert(key, curr);
                 }


### PR DESCRIPTION
## Summary
- \`predx watch\` に \`--log <path>\` を追加
- append mode でオープンし、threshold を超えたアラートと初回 baseline を追記
- 書き込み失敗はログ警告のみで監視ループは継続

Refs #6（#15 を先にマージしたため、当初スタックしていた #16 を閉じて main 起点で作り直したものです）

## Test plan
- [x] \`cargo test\`
- [x] \`--log /tmp/predx_test.log\` で1分回して baseline と tick ごとの変動が全部ファイルに書かれることを確認（append モードも確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)