### PR TITLE
feat(watch): --market-id で特定マーケットをピン留め追跡

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ predx watch "bitcoin" --threshold 3 --webhook https://hooks.slack.com/services/.
 
 # ファイルに追記記録（baseline とアラートをすべて残す）
 predx watch "trump 2028" --log predx.log
+
+# 特定マーケットをID指定で追跡（複数指定可・プラットフォーム混在可）
+predx watch -m polymarket:1733817 -m kalshi:KXPRESNOMD-28-GN
 ```
 
 ### 出力例

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -4,8 +4,8 @@ use serde::Deserialize;
 
 use crate::market::{Market, MarketItem};
 
-const SEARCH_URL: &str =
-    "https://api.elections.kalshi.com/v1/search/series";
+const SEARCH_URL: &str = "https://api.elections.kalshi.com/v1/search/series";
+const MARKET_URL: &str = "https://api.elections.kalshi.com/trade-api/v2/markets";
 const PAGE_SIZE: u32 = 24;
 
 pub struct Kalshi {
@@ -63,6 +63,48 @@ impl Market for Kalshi {
         }
         Ok(items)
     }
+
+    async fn get_by_id(&self, id: &str) -> Result<MarketItem> {
+        let url = format!("{}/{}", MARKET_URL, id);
+        let resp: V2MarketResponse = self.client.get(&url).send().await?.json().await?;
+        let m = resp.market;
+        let probability = m.last_price_dollars.parse::<f64>().unwrap_or(0.0);
+        let volume = m.volume_fp.parse::<f64>().unwrap_or(0.0);
+        let title = if m.yes_sub_title.is_empty() {
+            m.title
+        } else {
+            format!("{} — {}", m.title, m.yes_sub_title)
+        };
+        Ok(MarketItem {
+            id: m.ticker,
+            platform: "kalshi",
+            title,
+            probability,
+            volume,
+            active: m.status == "active",
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct V2MarketResponse {
+    market: V2Market,
+}
+
+#[derive(Deserialize)]
+struct V2Market {
+    #[serde(default)]
+    ticker: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    yes_sub_title: String,
+    #[serde(default)]
+    last_price_dollars: String,
+    #[serde(default)]
+    volume_fp: String,
+    #[serde(default)]
+    status: String,
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,12 @@ enum Commands {
 
     /// Watch markets and report when probability changes exceed a threshold
     Watch {
-        /// Search query (e.g. "trump 2028")
-        query: String,
+        /// Search query (e.g. "trump 2028"). Omit when using --market-id
+        query: Option<String>,
+
+        /// Track specific markets. Format: "polymarket:<id>" or "kalshi:<ticker>". Repeatable
+        #[arg(short, long = "market-id")]
+        market_ids: Vec<String>,
 
         /// Polling interval in seconds
         #[arg(short, long, default_value_t = 60)]
@@ -71,7 +75,7 @@ enum Commands {
         #[arg(short, long, default_value_t = 5.0)]
         threshold: f64,
 
-        /// Number of top markets per platform to watch
+        /// Number of top markets per platform to watch (query mode only)
         #[arg(short, long, default_value_t = 5)]
         limit: usize,
 
@@ -232,14 +236,29 @@ async fn main() -> anyhow::Result<()> {
 
             Ok(())
         }
-        Commands::Watch { query, interval, threshold, limit, duration, webhook, log } => {
+        Commands::Watch { query, market_ids, interval, threshold, limit, duration, webhook, log } => {
             let limit = limit.clamp(1, 100);
             let interval = interval.max(1);
+
+            let target = match (query, market_ids.is_empty()) {
+                (Some(q), true) => watch::WatchTarget::Query { query: q, limit },
+                (None, false) => {
+                    let ids: Result<Vec<_>, _> =
+                        market_ids.iter().map(|s| watch::parse_market_id(s)).collect();
+                    watch::WatchTarget::Ids(ids?)
+                }
+                (Some(_), false) => anyhow::bail!(
+                    "specify either a search query or --market-id, not both",
+                ),
+                (None, true) => anyhow::bail!(
+                    "specify a search query or at least one --market-id",
+                ),
+            };
+
             watch::run(watch::WatchOptions {
-                query,
+                target,
                 interval,
                 threshold,
-                limit,
                 duration,
                 webhook,
                 log,

--- a/src/market.rs
+++ b/src/market.rs
@@ -18,4 +18,5 @@ pub struct MarketItem {
 pub trait Market {
     fn name(&self) -> &str;
     async fn search(&self, query: &str) -> Result<Vec<MarketItem>>;
+    async fn get_by_id(&self, id: &str) -> Result<MarketItem>;
 }

--- a/src/polymarket.rs
+++ b/src/polymarket.rs
@@ -5,7 +5,20 @@ use serde::Deserialize;
 use crate::market::{Market, MarketItem};
 
 const SEARCH_URL: &str = "https://gamma-api.polymarket.com/public-search";
+const MARKET_URL: &str = "https://gamma-api.polymarket.com/markets";
 const DEFAULT_LIMIT: u32 = 10;
+
+fn to_item(m: PolymarketMarket) -> MarketItem {
+    let probability = parse_yes_price(&m.outcome_prices);
+    MarketItem {
+        id: m.id,
+        platform: "polymarket",
+        title: m.question,
+        probability,
+        volume: m.volume.parse::<f64>().unwrap_or(0.0),
+        active: m.active && !m.closed,
+    }
+}
 
 pub struct Polymarket {
     client: reqwest::Client,
@@ -38,18 +51,16 @@ impl Market for Polymarket {
         let mut items = Vec::new();
         for event in resp.events {
             for market in event.markets {
-                let probability = parse_yes_price(&market.outcome_prices);
-                items.push(MarketItem {
-                    id: market.id,
-                    platform: "polymarket",
-                    title: market.question,
-                    probability,
-                    volume: market.volume.parse::<f64>().unwrap_or(0.0),
-                    active: market.active && !market.closed,
-                });
+                items.push(to_item(market));
             }
         }
         Ok(items)
+    }
+
+    async fn get_by_id(&self, id: &str) -> Result<MarketItem> {
+        let url = format!("{}/{}", MARKET_URL, id);
+        let m: PolymarketMarket = self.client.get(&url).send().await?.json().await?;
+        Ok(to_item(m))
     }
 }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -12,14 +12,38 @@ use crate::kalshi::Kalshi;
 use crate::market::{Market, MarketItem};
 use crate::polymarket::Polymarket;
 
+pub enum WatchTarget {
+    Query { query: String, limit: usize },
+    Ids(Vec<MarketId>),
+}
+
+pub struct MarketId {
+    pub platform: String,
+    pub id: String,
+}
+
 pub struct WatchOptions {
-    pub query: String,
+    pub target: WatchTarget,
     pub interval: u64,
     pub threshold: f64,
-    pub limit: usize,
     pub duration: Option<u64>,
     pub webhook: Option<String>,
     pub log: Option<PathBuf>,
+}
+
+pub fn parse_market_id(raw: &str) -> Result<MarketId> {
+    let (platform, id) = raw
+        .split_once(':')
+        .with_context(|| format!("invalid --market-id \"{}\" (expected platform:id)", raw))?;
+    let platform = platform.trim().to_ascii_lowercase();
+    let id = id.trim().to_string();
+    if !matches!(platform.as_str(), "polymarket" | "kalshi") {
+        anyhow::bail!("unknown platform \"{}\": use polymarket or kalshi", platform);
+    }
+    if id.is_empty() {
+        anyhow::bail!("market id cannot be empty");
+    }
+    Ok(MarketId { platform, id })
 }
 
 fn append_log(path: &PathBuf, line: &str) -> Result<()> {
@@ -66,10 +90,18 @@ pub async fn run(opts: WatchOptions) -> Result<()> {
     let mut prev: HashMap<String, f64> = HashMap::new();
     let mut tick = 0u64;
 
-    println!(
-        "# watching \"{}\" — interval={}s threshold={}% limit={}",
-        opts.query, opts.interval, opts.threshold, opts.limit,
-    );
+    match &opts.target {
+        WatchTarget::Query { query, limit } => println!(
+            "# watching \"{}\" — interval={}s threshold={}% limit={}",
+            query, opts.interval, opts.threshold, limit,
+        ),
+        WatchTarget::Ids(ids) => println!(
+            "# watching {} market(s) — interval={}s threshold={}%",
+            ids.len(),
+            opts.interval,
+            opts.threshold,
+        ),
+    }
     if let Some(d) = opts.duration {
         println!("# stop after {} minute(s)", d);
     }
@@ -82,7 +114,7 @@ pub async fn run(opts: WatchOptions) -> Result<()> {
     println!("# press Ctrl+C to stop");
 
     loop {
-        let snapshot = fetch_snapshot(&poly, &kal, &opts.query, opts.limit).await;
+        let snapshot = fetch_snapshot(&poly, &kal, &opts.target).await;
         match snapshot {
             Ok(items) => {
                 let now = chrono_now();
@@ -152,24 +184,43 @@ pub async fn run(opts: WatchOptions) -> Result<()> {
 async fn fetch_snapshot(
     poly: &Polymarket,
     kal: &Kalshi,
-    query: &str,
-    limit: usize,
+    target: &WatchTarget,
 ) -> Result<Vec<MarketItem>> {
-    let (mut poly_res, mut kal_res) = tokio::try_join!(poly.search(query), kal.search(query))?;
-    poly_res.retain(|item| item.active);
-    kal_res.retain(|item| item.active);
+    match target {
+        WatchTarget::Query { query, limit } => {
+            let (mut poly_res, mut kal_res) =
+                tokio::try_join!(poly.search(query), kal.search(query))?;
+            poly_res.retain(|item| item.active);
+            kal_res.retain(|item| item.active);
 
-    let cmp = |a: &MarketItem, b: &MarketItem| {
-        b.volume
-            .partial_cmp(&a.volume)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    };
-    poly_res.sort_by(cmp);
-    kal_res.sort_by(cmp);
+            let cmp = |a: &MarketItem, b: &MarketItem| {
+                b.volume
+                    .partial_cmp(&a.volume)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            };
+            poly_res.sort_by(cmp);
+            kal_res.sort_by(cmp);
 
-    let mut items: Vec<MarketItem> = poly_res.into_iter().take(limit).collect();
-    items.extend(kal_res.into_iter().take(limit));
-    Ok(items)
+            let mut items: Vec<MarketItem> = poly_res.into_iter().take(*limit).collect();
+            items.extend(kal_res.into_iter().take(*limit));
+            Ok(items)
+        }
+        WatchTarget::Ids(ids) => {
+            let mut items = Vec::with_capacity(ids.len());
+            for mid in ids {
+                let result = match mid.platform.as_str() {
+                    "polymarket" => poly.get_by_id(&mid.id).await,
+                    "kalshi" => kal.get_by_id(&mid.id).await,
+                    other => anyhow::bail!("unknown platform: {}", other),
+                };
+                match result {
+                    Ok(item) => items.push(item),
+                    Err(e) => eprintln!("[warn] fetch {}:{} failed: {}", mid.platform, mid.id, e),
+                }
+            }
+            Ok(items)
+        }
+    }
 }
 
 fn chrono_now() -> String {


### PR DESCRIPTION
## Summary
- \`Market\` trait に \`get_by_id\` を追加し、Polymarket / Kalshi それぞれの単体マーケット取得 API を呼ぶ
  - Polymarket: \`GET /markets/{id}\`
  - Kalshi: \`GET /trade-api/v2/markets/{ticker}\`（v2 に新規に接続）
- \`predx watch -m polymarket:<id> -m kalshi:<ticker>\` の形式で複数市場を同時追跡
- \`query\` と \`--market-id\` は排他、どちらか必須（バリデーションエラーでわかりやすく失敗）

Closes #6

## Test plan
- [x] \`cargo test\`
- [x] \`predx watch\`（引数なし）→ バリデーションエラー
- [x] \`predx watch trump -m polymarket:123\`（同時指定）→ バリデーションエラー
- [x] \`predx watch -m bad-format\` → パースエラー
- [x] \`predx watch -m polymarket:1733817 -m kalshi:KXPRESNOMD-28-GN --interval 3 --threshold 0.0 --duration 1\` → 両プラットフォームの baseline + tick ごとの変化が取得できることを確認

## 設計メモ
- Polymarket の search はレスポンスが \`{events: [{markets: [...]}]}\` だが、単体取得は \`PolymarketMarket\` 直下の形状。既存の構造体をそのまま流用できた
- Kalshi は search が v1、単体取得は v2 という API 不整合。単体用に \`V2MarketResponse\` / \`V2Market\` を新設（search 側には触らない）
- ID フェッチは 2 件程度前提の逐次実行。大量指定は当面想定外なので並列化は見送り

🤖 Generated with [Claude Code](https://claude.com/claude-code)